### PR TITLE
[#158688475] No longer hash GUID in instance name.

### DIFF
--- a/ci/integration/integration_test.go
+++ b/ci/integration/integration_test.go
@@ -208,7 +208,7 @@ func pollForBackupCompletion(instanceID string) {
 				} `json:"service"`
 			}
 
-			serviceName := provider.BuildServiceName(os.Getenv("SERVICE_NAME_PREFIX"), instanceID)
+			serviceName := os.Getenv("SERVICE_NAME_PREFIX") + "-" + instanceID
 			req, err := http.NewRequest("GET", fmt.Sprintf(
 				"https://api.aiven.io/v1beta/project/%s/service/%s",
 				os.Getenv("AIVEN_PROJECT"),

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -142,7 +142,7 @@ func (ap *AivenProvider) LastOperation(ctx context.Context, lastOperationData La
 		return brokerapi.InProgress, "Preparing to apply update", nil
 	}
 
-	lastOperationState, description := ProviderStatesMapping(status)
+	lastOperationState, description := providerStatesMapping(status)
 	return lastOperationState, description, nil
 }
 
@@ -151,7 +151,7 @@ func BuildServiceName(prefix, guid string) string {
 	return fmt.Sprintf("%s%x", prefix, checksum)
 }
 
-func ProviderStatesMapping(status aiven.ServiceStatus) (brokerapi.LastOperationState, string) {
+func providerStatesMapping(status aiven.ServiceStatus) (brokerapi.LastOperationState, string) {
 	switch status {
 	case aiven.Running:
 		return brokerapi.Succeeded, "Last operation succeeded"

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -3,8 +3,8 @@ package provider
 import (
 	"context"
 	"fmt"
-	"hash/crc32"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/alphagov/paas-aiven-broker/provider/aiven"
@@ -39,7 +39,7 @@ func (ap *AivenProvider) Provision(ctx context.Context, provisionData ProvisionD
 	createServiceInput := &aiven.CreateServiceInput{
 		Cloud:       ap.Config.Cloud,
 		Plan:        plan.AivenPlan,
-		ServiceName: BuildServiceName(ap.Config.ServiceNamePrefix, provisionData.InstanceID),
+		ServiceName: buildServiceName(ap.Config.ServiceNamePrefix, provisionData.InstanceID),
 		ServiceType: SERVICE_TYPE,
 		UserConfig: aiven.UserConfig{
 			ElasticsearchVersion: plan.ElasticsearchVersion,
@@ -51,7 +51,7 @@ func (ap *AivenProvider) Provision(ctx context.Context, provisionData ProvisionD
 
 func (ap *AivenProvider) Deprovision(ctx context.Context, deprovisionData DeprovisionData) (operationData string, err error) {
 	_, err = ap.Client.DeleteService(&aiven.DeleteServiceInput{
-		ServiceName: BuildServiceName(ap.Config.ServiceNamePrefix, deprovisionData.InstanceID),
+		ServiceName: buildServiceName(ap.Config.ServiceNamePrefix, deprovisionData.InstanceID),
 	})
 	if err != nil {
 		return "", err
@@ -67,7 +67,7 @@ type Credentials struct {
 func (ap *AivenProvider) Bind(ctx context.Context, bindData BindData) (binding brokerapi.Binding, err error) {
 	user := bindData.BindingID
 	password, err := ap.Client.CreateServiceUser(&aiven.CreateServiceUserInput{
-		ServiceName: BuildServiceName(ap.Config.ServiceNamePrefix, bindData.InstanceID),
+		ServiceName: buildServiceName(ap.Config.ServiceNamePrefix, bindData.InstanceID),
 		Username:    user,
 	})
 	if err != nil {
@@ -75,7 +75,7 @@ func (ap *AivenProvider) Bind(ctx context.Context, bindData BindData) (binding b
 	}
 
 	host, port, err := ap.Client.GetServiceConnectionDetails(&aiven.GetServiceInput{
-		ServiceName: BuildServiceName(ap.Config.ServiceNamePrefix, bindData.InstanceID),
+		ServiceName: buildServiceName(ap.Config.ServiceNamePrefix, bindData.InstanceID),
 	})
 	if err != nil {
 		return brokerapi.Binding{}, err
@@ -107,7 +107,7 @@ func buildUri(user, password, host, port string) string {
 
 func (ap *AivenProvider) Unbind(ctx context.Context, unbindData UnbindData) (err error) {
 	_, err = ap.Client.DeleteServiceUser(&aiven.DeleteServiceUserInput{
-		ServiceName: BuildServiceName(ap.Config.ServiceNamePrefix, unbindData.InstanceID),
+		ServiceName: buildServiceName(ap.Config.ServiceNamePrefix, unbindData.InstanceID),
 		Username:    unbindData.BindingID,
 	})
 	return err
@@ -120,7 +120,7 @@ func (ap *AivenProvider) Update(ctx context.Context, updateData UpdateData) (ope
 	}
 
 	_, err = ap.Client.UpdateService(&aiven.UpdateServiceInput{
-		ServiceName: BuildServiceName(ap.Config.ServiceNamePrefix, updateData.InstanceID),
+		ServiceName: buildServiceName(ap.Config.ServiceNamePrefix, updateData.InstanceID),
 		Plan:        plan.AivenPlan,
 	})
 	if err != nil {
@@ -132,7 +132,7 @@ func (ap *AivenProvider) Update(ctx context.Context, updateData UpdateData) (ope
 
 func (ap *AivenProvider) LastOperation(ctx context.Context, lastOperationData LastOperationData) (state brokerapi.LastOperationState, description string, err error) {
 	status, updateTime, err := ap.Client.GetServiceStatus(&aiven.GetServiceInput{
-		ServiceName: BuildServiceName(ap.Config.ServiceNamePrefix, lastOperationData.InstanceID),
+		ServiceName: buildServiceName(ap.Config.ServiceNamePrefix, lastOperationData.InstanceID),
 	})
 	if err != nil {
 		return "", "", err
@@ -146,9 +146,8 @@ func (ap *AivenProvider) LastOperation(ctx context.Context, lastOperationData La
 	return lastOperationState, description, nil
 }
 
-func BuildServiceName(prefix, guid string) string {
-	checksum := crc32.ChecksumIEEE([]byte(guid))
-	return fmt.Sprintf("%s%x", prefix, checksum)
+func buildServiceName(prefix, guid string) string {
+	return strings.ToLower(prefix + "-" + guid)
 }
 
 func providerStatesMapping(status aiven.ServiceStatus) (brokerapi.LastOperationState, string) {

--- a/provider/provider_internals_test.go
+++ b/provider/provider_internals_test.go
@@ -5,45 +5,22 @@ import (
 	"github.com/pivotal-cf/brokerapi"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Provider internals", func() {
 
-	Describe("providerStatesMapping", func() {
-		It("should return 'succeeded' when RUNNING", func() {
-			state, description := providerStatesMapping(aiven.Running)
-
-			Expect(state).To(Equal(brokerapi.Succeeded))
-			Expect(description).To(Equal("Last operation succeeded"))
-		})
-
-		It("should return 'in progress' when REBUILDING", func() {
-			state, description := providerStatesMapping(aiven.Rebuilding)
-
-			Expect(state).To(Equal(brokerapi.InProgress))
-			Expect(description).To(Equal("Rebuilding"))
-		})
-
-		It("should return 'in progress' when REBALANCING", func() {
-			state, description := providerStatesMapping(aiven.Rebalancing)
-
-			Expect(state).To(Equal(brokerapi.InProgress))
-			Expect(description).To(Equal("Rebalancing"))
-		})
-
-		It("should return 'failed' when POWEROFF", func() {
-			state, description := providerStatesMapping(aiven.PowerOff)
-
-			Expect(state).To(Equal(brokerapi.Failed))
-			Expect(description).To(Equal("Last operation failed: service is powered off"))
-		})
-
-		It("should return 'in progress' by default", func() {
-			state, description := providerStatesMapping("foo")
-
-			Expect(state).To(Equal(brokerapi.InProgress))
-			Expect(description).To(Equal("Unknown state: foo"))
-		})
-	})
+	DescribeTable("providerStatesMapping",
+		func(inputState aiven.ServiceStatus, expectedState brokerapi.LastOperationState, expectedDescription string) {
+			state, description := providerStatesMapping(inputState)
+			Expect(state).To(Equal(expectedState))
+			Expect(description).To(Equal(expectedDescription))
+		},
+		Entry("returns 'succeeded' when RUNNING", aiven.Running, brokerapi.Succeeded, "Last operation succeeded"),
+		Entry("returns 'in progress' when REBUILDING", aiven.Rebuilding, brokerapi.InProgress, "Rebuilding"),
+		Entry("returns 'in progress' when REBALANCING", aiven.Rebalancing, brokerapi.InProgress, "Rebalancing"),
+		Entry("returns 'failed' when POWEROFF", aiven.PowerOff, brokerapi.Failed, "Last operation failed: service is powered off"),
+		Entry("returns 'in progress' by default", aiven.ServiceStatus("foo"), brokerapi.InProgress, "Unknown state: foo"),
+	)
 })

--- a/provider/provider_internals_test.go
+++ b/provider/provider_internals_test.go
@@ -11,6 +11,14 @@ import (
 
 var _ = Describe("Provider internals", func() {
 
+	DescribeTable("buildServiceName",
+		func(prefix, instanceId, expected string) {
+			Expect(buildServiceName(prefix, instanceId)).To(Equal(expected))
+		},
+		Entry("combines prefix and instanceId", "env", "09e1993e-62e2-4040-adf2-4d3ec741efe6", "env-09e1993e-62e2-4040-adf2-4d3ec741efe6"),
+		Entry("downcases everything", "Env", "09E1993E-62E2-4040-ADF2-4D3EC741EFE6", "env-09e1993e-62e2-4040-adf2-4d3ec741efe6"),
+	)
+
 	DescribeTable("providerStatesMapping",
 		func(inputState aiven.ServiceStatus, expectedState brokerapi.LastOperationState, expectedDescription string) {
 			state, description := providerStatesMapping(inputState)

--- a/provider/provider_internals_test.go
+++ b/provider/provider_internals_test.go
@@ -1,0 +1,49 @@
+package provider
+
+import (
+	"github.com/alphagov/paas-aiven-broker/provider/aiven"
+	"github.com/pivotal-cf/brokerapi"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Provider internals", func() {
+
+	Describe("providerStatesMapping", func() {
+		It("should return 'succeeded' when RUNNING", func() {
+			state, description := providerStatesMapping(aiven.Running)
+
+			Expect(state).To(Equal(brokerapi.Succeeded))
+			Expect(description).To(Equal("Last operation succeeded"))
+		})
+
+		It("should return 'in progress' when REBUILDING", func() {
+			state, description := providerStatesMapping(aiven.Rebuilding)
+
+			Expect(state).To(Equal(brokerapi.InProgress))
+			Expect(description).To(Equal("Rebuilding"))
+		})
+
+		It("should return 'in progress' when REBALANCING", func() {
+			state, description := providerStatesMapping(aiven.Rebalancing)
+
+			Expect(state).To(Equal(brokerapi.InProgress))
+			Expect(description).To(Equal("Rebalancing"))
+		})
+
+		It("should return 'failed' when POWEROFF", func() {
+			state, description := providerStatesMapping(aiven.PowerOff)
+
+			Expect(state).To(Equal(brokerapi.Failed))
+			Expect(description).To(Equal("Last operation failed: service is powered off"))
+		})
+
+		It("should return 'in progress' by default", func() {
+			state, description := providerStatesMapping("foo")
+
+			Expect(state).To(Equal(brokerapi.InProgress))
+			Expect(description).To(Equal("Unknown state: foo"))
+		})
+	})
+})

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -310,41 +310,4 @@ var _ = Describe("Provider", func() {
 			Expect(description).To(Equal(""))
 		})
 	})
-
-	Describe("ProviderStatesMapping", func() {
-		It("should return 'succeeded' when RUNNING", func() {
-			state, description := provider.ProviderStatesMapping(aiven.Running)
-
-			Expect(state).To(Equal(brokerapi.Succeeded))
-			Expect(description).To(Equal("Last operation succeeded"))
-		})
-
-		It("should return 'in progress' when REBUILDING", func() {
-			state, description := provider.ProviderStatesMapping(aiven.Rebuilding)
-
-			Expect(state).To(Equal(brokerapi.InProgress))
-			Expect(description).To(Equal("Rebuilding"))
-		})
-
-		It("should return 'in progress' when REBALANCING", func() {
-			state, description := provider.ProviderStatesMapping(aiven.Rebalancing)
-
-			Expect(state).To(Equal(brokerapi.InProgress))
-			Expect(description).To(Equal("Rebalancing"))
-		})
-
-		It("should return 'failed' when POWEROFF", func() {
-			state, description := provider.ProviderStatesMapping(aiven.PowerOff)
-
-			Expect(state).To(Equal(brokerapi.Failed))
-			Expect(description).To(Equal("Last operation failed: service is powered off"))
-		})
-
-		It("should return 'in progress' by default", func() {
-			state, description := provider.ProviderStatesMapping("foo")
-
-			Expect(state).To(Equal(brokerapi.InProgress))
-			Expect(description).To(Equal("Unknown state: foo"))
-		})
-	})
 })

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Provider", func() {
 			expectedParameters := &aiven.CreateServiceInput{
 				Cloud:       "aws-eu-west-1",
 				Plan:        "startup-1",
-				ServiceName: "env69bc39f8",
+				ServiceName: "env-09e1993e-62e2-4040-adf2-4d3ec741efe6",
 				ServiceType: "elasticsearch",
 				UserConfig: aiven.UserConfig{
 					ElasticsearchVersion: "6",
@@ -101,7 +101,7 @@ var _ = Describe("Provider", func() {
 			Expect(fakeAivenClient.DeleteServiceCallCount()).To(Equal(1))
 
 			expectedParameters := &aiven.DeleteServiceInput{
-				ServiceName: "env69bc39f8",
+				ServiceName: "env-09e1993e-62e2-4040-adf2-4d3ec741efe6",
 			}
 			Expect(fakeAivenClient.DeleteServiceArgsForCall(0)).To(Equal(expectedParameters))
 		})
@@ -131,13 +131,13 @@ var _ = Describe("Provider", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			expectedCreateServiceUserParameters := &aiven.CreateServiceUserInput{
-				ServiceName: "env69bc39f8",
+				ServiceName: "env-09e1993e-62e2-4040-adf2-4d3ec741efe6",
 				Username:    bindData.BindingID,
 			}
 			Expect(fakeAivenClient.CreateServiceUserArgsForCall(0)).To(Equal(expectedCreateServiceUserParameters))
 
 			expectedGetServiceConnectionDetailsParameters := &aiven.GetServiceInput{
-				ServiceName: "env69bc39f8",
+				ServiceName: "env-09e1993e-62e2-4040-adf2-4d3ec741efe6",
 			}
 			Expect(fakeAivenClient.GetServiceConnectionDetailsArgsForCall(0)).To(Equal(expectedGetServiceConnectionDetailsParameters))
 
@@ -188,7 +188,7 @@ var _ = Describe("Provider", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			expectedDeleteServiceUserParameters := &aiven.DeleteServiceUserInput{
-				ServiceName: "env69bc39f8",
+				ServiceName: "env-09e1993e-62e2-4040-adf2-4d3ec741efe6",
 				Username:    unbindData.BindingID,
 			}
 
@@ -223,7 +223,7 @@ var _ = Describe("Provider", func() {
 			Expect(fakeAivenClient.UpdateServiceCallCount()).To(Equal(1))
 
 			expectedParameters := &aiven.UpdateServiceInput{
-				ServiceName: "env69bc39f8",
+				ServiceName: "env-09e1993e-62e2-4040-adf2-4d3ec741efe6",
 				Plan:        "startup-2",
 			}
 			Expect(fakeAivenClient.UpdateServiceArgsForCall(0)).To(Equal(expectedParameters))
@@ -250,7 +250,7 @@ var _ = Describe("Provider", func() {
 	Describe("LastOperation", func() {
 		It("should return succeeded when the service is running", func() {
 			expectedGetServiceStatusParameters := &aiven.GetServiceInput{
-				ServiceName: "env69bc39f8",
+				ServiceName: "env-09e1993e-62e2-4040-adf2-4d3ec741efe6",
 			}
 
 			lastOperationData := provider.LastOperationData{
@@ -276,7 +276,7 @@ var _ = Describe("Provider", func() {
 		Context("when the state is RUNNING, but the service has only just been updated", func() {
 			It("should report it 'in progress' for up to 60 seconds after the updated time", func() {
 				expectedGetServiceParameters := &aiven.GetServiceInput{
-					ServiceName: "env69bc39f8",
+					ServiceName: "env-09e1993e-62e2-4040-adf2-4d3ec741efe6",
 				}
 
 				lastOperationData := provider.LastOperationData{


### PR DESCRIPTION
## What

The instance name was previously limited to 16 characters, so we had to
hash the instanceID (a GUID) using crc32 to get something that would
fit.

Since then Aiven have relaxed this limit and it's now possible to
use instance names up to 64 characters. This therefore removes the crc32
hashing, and merely appends the instanceID to the prefix.

I've taken this opportunity to refactor some of the internal functions in the provider
package so that they're no longer exported. See commits for details.

## How to review

Code review.  Verify all the tests still pass.

## Who can review

Not me.