### PR TITLE
[#159492539] Add IP whitelisting.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,4 @@ unit:
 	$(eval export SERVICE_NAME_PREFIX=test)
 	$(eval export AIVEN_API_TOKEN=token)
 	$(eval export AIVEN_PROJECT=project)
-	ginkgo -r --skipPackage=ci
+	ginkgo $(COMMAND) -r --skipPackage=ci $(PACKAGE)

--- a/provider/aiven/client.go
+++ b/provider/aiven/client.go
@@ -47,7 +47,8 @@ type CreateServiceInput struct {
 }
 
 type UserConfig struct {
-	ElasticsearchVersion string `json:"elasticsearch_version"`
+	ElasticsearchVersion string   `json:"elasticsearch_version"`
+	IPFilter             []string `json:"ip_filter,omitempty"`
 }
 
 type DeleteServiceInput struct {

--- a/provider/aiven/client_test.go
+++ b/provider/aiven/client_test.go
@@ -35,6 +35,10 @@ var _ = Describe("Client", func() {
 				Plan:        "plan",
 				ServiceName: "name",
 				ServiceType: "type",
+				UserConfig: aiven.UserConfig{
+					ElasticsearchVersion: "6",
+					IPFilter:             []string{"1.2.3.4"},
+				},
 			}
 			expectedBody, _ := json.Marshal(createServiceInput)
 			aivenAPI.AppendHandlers(ghttp.CombineHandlers(


### PR DESCRIPTION
## What

To provide additional security to the elasticsearch endpoints the PaaS
egress IPs will be specified as a whitelist on the brokered instances,
preventing connections from other sources.

## How to review

1. Run unit tests (`make unit`)
1. From `paas-cf`: `SELF_UPDATE_PIPELINE=false BRANCH=elasticsearch_ip_whitelist make dev pipelines`
1. Create an `elasticsearch` service instance, bind it to an app and then test connectivity (I used `cf ssh` and `curl` from a staticfile app in my testing)
1. Verify that you cannot connect from elsewhere (I used my laptop at home on and off the VPN).

## Who can review

Anyone but me.
