### PR TITLE
[#159492539] Add IP whitelisting integration testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,12 @@
 
 test: unit integration
 
+integration: export EGRESS_IP=$(shell curl --silent icanhazip.com)
 integration:
-	ginkgo ci/integration
+	ginkgo -v ci/integration
 
+unit: export SERVICE_NAME_PREFIX=test
+unit: export AIVEN_API_TOKEN=token
+unit: export AIVEN_PROJECT=project
 unit:
-	$(eval export SERVICE_NAME_PREFIX=test)
-	$(eval export AIVEN_API_TOKEN=token)
-	$(eval export AIVEN_PROJECT=project)
 	ginkgo $(COMMAND) -r --skipPackage=ci $(PACKAGE)


### PR DESCRIPTION
## What

This PR adds a negative integration test to the Aiven Elasticsearch broker, and modifies an existing integration test. Taken together, these assert that Aiven's IP whitelist works as advertised.

## How to review

This is being added as part of the review of the previously (prematurely-merged) PR on the same story.

## Who can review

@blairboy362 and myself are doing&reviewing.