### PR TITLE
Update go version for buildpack upgrades

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -5,5 +5,5 @@ applications:
   instances: 2
   buildpack: go_buildpack
   env:
-    GOVERSION: go1.10.2
+    GOVERSION: go1.10.3
     GOPACKAGENAME: github.com/alphagov/paas-aiven-broker


### PR DESCRIPTION
## What
1.10.2 is not available in the new go buildpack. This commit updates go
to a version that is available throughout the update process.

## How to review

Code review and automated tests

## Who can review

Not @LeePorte
