### PR TITLE
[#159845792] Service update include user config and errors

### DIFF
--- a/ci/integration/integration_test.go
+++ b/ci/integration/integration_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Broker", func() {
 						"id": "uuid-2",
 						"name": "basic",
 						"aiven_plan": "startup-4",
-						"elasticsearch_version": "6"
+						"elasticsearch_version": "5"
 					}, {
 						"id": "uuid-3",
 						"name": "supra",
@@ -163,6 +163,11 @@ var _ = Describe("Broker", func() {
 			State:       brokerapi.Succeeded,
 			Description: "Last operation succeeded",
 		})
+
+		By("checking the version has actually been updated")
+		version, err := elasticsearchClient.Version()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(version).To(HavePrefix("6."))
 
 		By("Unbinding")
 		res = brokerTester.Unbind(instanceID, bindingID, brokertesting.RequestBody{


### PR DESCRIPTION
## What

We want to support plan changes of the service instances provided by this broker. Some plan changes are not supported by aiven itself. If the user tries to do an invalid operation the broker should reply with the right error.

The update service logic was already implemented. But for performing the instance update we must also include
the user_config struct with specifies the elasticsearch
version and IP filter.

Including the ES version would allow do version upgrades, and
the IP filter is needed to avoid potentially wiping the
existing values.

Additionally, Aiven would return an error if the udate is not
possible: major version downgrade, clustered to unclustered changes,
etc. This error is returned as 400 status and a json with the
human readable error.

We capture this error and return it
to the client as a 422 StatusUnprocessableEntity, as specified in
the broker api spec[1]. For any other error we also return the
body of the response, as it might be useful when troubleshooting
issues.

Tests have been updated to reflect all these changes.

[1] https://github.com/openservicebrokerapi/servicebroker/blob/v2.12/spec.md#response-3

## How to review

 - Code review
 - Tests should pass

## Who can review
Anyone