### PR TITLE
Relax Go version in the CF manifest.

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -5,5 +5,5 @@ applications:
   instances: 2
   buildpack: go_buildpack
   env:
-    GOVERSION: go1.10.3
+    GOVERSION: go1.10
     GOPACKAGENAME: github.com/alphagov/paas-aiven-broker


### PR DESCRIPTION
## What

By specifying this as 1.10 instead of 1.10.3 we'll get the latest patch
version of 1.10 that's available in the buildpack. At present we're
getting the following warning when deploying:

```
**WARNING** A newer version of go is available in this buildpack. Please adjust
your app to use version 1.10.4 instead of version 1.10.3 as soon as possible. Old
versions of go are only provided to assist in migrating to newer versions.
```

From the buildpack docs[1]:

> When specifying versions, specify only major/minor versions, such as
> Go 1.6, rather than Go 1.6.0. This ensures you receive the most recent
> patches.

I've confirmed that when pushing this app with 1.10 specified it
currently picks up 1.10.4

[1]https://docs.cloudfoundry.org/buildpacks/go/index.html#pushing_apps

## What

Describe what you have changed and why.

## How to review

Describe the steps required to test the changes.

## Who can review

Describe who can review the changes. Or more importantly, list the people
that can't review, because they worked on it.
