### PR TITLE
[#164045929] Fix user creation delay

### DIFF
--- a/ci/integration/integration_test.go
+++ b/ci/integration/integration_test.go
@@ -130,7 +130,7 @@ var _ = Describe("Broker", func() {
 		Expect(parsedResponse.Credentials).To(HaveKeyWithValue("username", BeAssignableToTypeOf(str)))
 		Expect(parsedResponse.Credentials).To(HaveKeyWithValue("password", BeAssignableToTypeOf(str)))
 
-		elasticsearchClient, _ := elastic.New(parsedResponse.Credentials["uri"].(string), nil)
+		elasticsearchClient := elastic.New(parsedResponse.Credentials["uri"].(string), nil)
 
 		By("Working around Aiven's slow DNS creation")
 		pollForAvailability(elasticsearchClient)
@@ -227,7 +227,7 @@ var _ = Describe("Broker", func() {
 		err := json.NewDecoder(res.Body).Decode(&parsedResponse)
 		Expect(err).ToNot(HaveOccurred())
 
-		elasticsearchClient, _ := elastic.New(parsedResponse.Credentials["uri"].(string), nil)
+		elasticsearchClient := elastic.New(parsedResponse.Credentials["uri"].(string), nil)
 
 		// Cargo cult. We don't *know* it's slow.
 		By("Waiting for Aiven's slow DNS creation to complete")

--- a/client/elastic/client.go
+++ b/client/elastic/client.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 )
 
@@ -22,12 +21,12 @@ type elasticsearchResponse struct {
 	Version elasticsearchResponseVersion `json:"version,omitempty"`
 }
 
-func New(uri string, httpClient *http.Client) (*Client, error) {
+func New(uri string, httpClient *http.Client) *Client {
 	if httpClient == nil {
 		httpClient = &http.Client{}
 	}
 
-	return &Client{http: httpClient, URI: uri}, nil
+	return &Client{http: httpClient, URI: uri}
 }
 
 func (c *Client) Ping() (*elasticsearchResponse, error) {
@@ -49,14 +48,9 @@ func (c *Client) Ping() (*elasticsearchResponse, error) {
 	return r, nil
 }
 
-func (c *Client) readBody(body io.ReadCloser) (*elasticsearchResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(body)
-	if err != nil {
-		return nil, err
-	}
-
+func (c *Client) readBody(body io.Reader) (*elasticsearchResponse, error) {
 	data := elasticsearchResponse{}
-	err = json.Unmarshal(bodyBytes, &data)
+	err := json.NewDecoder(body).Decode(&data)
 	if err != nil {
 		return nil, err
 	}

--- a/client/elastic/client.go
+++ b/client/elastic/client.go
@@ -23,7 +23,7 @@ type elasticsearchResponse struct {
 
 func New(uri string, httpClient *http.Client) *Client {
 	if httpClient == nil {
-		httpClient = &http.Client{}
+		httpClient = http.DefaultClient
 	}
 
 	return &Client{http: httpClient, URI: uri}

--- a/client/elastic/client_test.go
+++ b/client/elastic/client_test.go
@@ -22,10 +22,7 @@ var _ = Describe("Elastic Client", func() {
 	)
 
 	BeforeEach(func() {
-		var err error
-		client, err = New("http://localhost:9200", nil)
-
-		Expect(err).NotTo(HaveOccurred())
+		client = New("http://localhost:9200", nil)
 	})
 
 	It("should create New() client", func() {


### PR DESCRIPTION
## What

We've seen issues where the credentials returned by the Aiven API don't
work for a short period after creation - the ES endpoint returns 401
errors. This has caused things like our acceptance tests to fail.

This adds a polling loop to the bind call to wait until the credentials
successfully connect. Becuase this is only a best-effort workaround, if
the polling times out, it returns anyway.

With this in place, there's no longer a need to have the polling in the
integration tests, so this is also removed.

## How to review

* Code review
* Verify all tests pass.

## Who can review

Not me.
