### PR TITLE
Remove Elastisearch 5.x integration tests

### DIFF
--- a/ci/integration/integration_test.go
+++ b/ci/integration/integration_test.go
@@ -39,11 +39,6 @@ var _ = Describe("Broker", func() {
 				"id": "uuid-service",
 				"plan_updateable": true,
 				"plans": [{
-					"id": "uuid-basic-5",
-					"name": "basic-5",
-					"aiven_plan": "startup-4",
-					"elasticsearch_version": "5"
-				}, {
 					"id": "uuid-basic-6",
 					"name": "basic-6",
 					"aiven_plan": "startup-4",
@@ -102,7 +97,7 @@ var _ = Describe("Broker", func() {
 		By("Provisioning")
 		res := brokerTester.Provision(instanceID, brokertesting.RequestBody{
 			ServiceID: "uuid-service",
-			PlanID:    "uuid-basic-5",
+			PlanID:    "uuid-basic-6",
 		}, ASYNC_ALLOWED)
 		Expect(res.Code).To(Equal(http.StatusAccepted))
 
@@ -115,7 +110,7 @@ var _ = Describe("Broker", func() {
 		By("Binding")
 		res = brokerTester.Bind(instanceID, bindingID, brokertesting.RequestBody{
 			ServiceID: "uuid-service",
-			PlanID:    "uuid-basic-5",
+			PlanID:    "uuid-basic-6",
 		})
 		Expect(res.Code).To(Equal(http.StatusCreated))
 


### PR DESCRIPTION
## What
Elasticsearch 5.x is at its end of life and no longer being provided by the broker. This commit removes the integration tests for it.

## How to review
Code review and check the integration tests passed.

## Who can review
Not @tnwhitwell or @AP-Hunt 
