### PR TITLE
Improve resiliency of Unbind to errors from Aiven

### DIFF
--- a/provider/aiven/client.go
+++ b/provider/aiven/client.go
@@ -252,8 +252,15 @@ func (a *HttpClient) DeleteServiceUser(params *DeleteServiceUserInput) (string, 
 	if err != nil {
 		return "", err
 	}
+
 	if res.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("Error deleting service user: %d status code returned from Aiven: '%s'", res.StatusCode, b)
+		var errorResponse AivenErrorResponse
+		jsonErr := json.Unmarshal(b, &errorResponse)
+
+		expectedMessageIfUserWasAlreadyDeleted := fmt.Sprintf("Service user '%s' does not exist", params.Username)
+		if jsonErr != nil || errorResponse.Message != expectedMessageIfUserWasAlreadyDeleted {
+			return "", fmt.Errorf("Error deleting service user: %d status code returned from Aiven: '%s'", res.StatusCode, b)
+		}
 	}
 
 	return string(b), nil


### PR DESCRIPTION
## What

In a recent support ticket, a tenant reported that unbinding their app from an Elasticsearch was failing:

> Service broker error: Error deleting service user: 403 status code returned from Aiven: `'{"errors":[{"message":"Service user 'GUIDGUID-GUID-GUID-GUID-GUIDGUIDGUID' does not exist`

(Where GUID is a placeholder for the real GUID involved.)

I investigated and found that on the first attempt to unbind, Aiven returned a `502 Bad Gateway` error when the broker attempted to delete the binding's Elasticsearch user. It seems that Aiven did delete the user despite that error response.

This commit has the broker detect when a user does not exist, such as when it has already been deleted. This should prevent this problem from recurring and help maintain our tenants' confidence in us.

## How to review

* See if the tests pass;
* Code review.

An alternative implementation would have been to `GET` the user and only attempt to delete it if it already existed. I chose to always do the `DELETE` because it was easier to implement.

## Who can review

Not @46bit