### PR TITLE
[#167506774] Bump version of Golang used to 1.12

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -5,5 +5,5 @@ applications:
   instances: 2
   buildpack: go_buildpack
   env:
-    GOVERSION: go1.10
+    GOVERSION: go1.12
     GOPACKAGENAME: github.com/alphagov/paas-aiven-broker


### PR DESCRIPTION
## What

The Go buildpack deployed to the PaaS has dropped support for Go 1.10 as of [1.8.41](https://github.com/cloudfoundry/go-buildpack/releases/tag/v1.8.41).

## How to review

1. Code review
1. Check the integration tests

## Who can review
Anyone