### PR TITLE
[#170180331] Use Credhub for secrets in integration test pipeline

### DIFF
--- a/ci/integration.yml
+++ b/ci/integration.yml
@@ -7,17 +7,15 @@ image_resource:
     tag: c88f3e0b03558c987693fad3f180d9052b77342c
 inputs:
   - name: repo
-  - name: secrets
+params:
+  AIVEN_API_TOKEN: ((aiven_api_token))
+  AIVEN_PROJECT: ((aiven_project))
 run:
   path: sh
   args:
     - -e
     - -c
     - |
-      AIVEN_API_TOKEN="$(awk -F':' '$1 ~ /aiven_api_token/ {print $2}' "./secrets/$SECRETS_FILE" | sed -e 's/^\s*//')"
-      export AIVEN_API_TOKEN
-      AIVEN_PROJECT="$(awk -F':' '$1 ~ /aiven_project/ {print $2}' "./secrets/$SECRETS_FILE" | sed -e 's/^\s*//')"
-      export AIVEN_PROJECT
       SERVICE_NAME_PREFIX=test
       export SERVICE_NAME_PREFIX
       AIVEN_USERNAME=foo


### PR DESCRIPTION
## What
Gets the `AIVEN_API_TOKEN` and `AIVEN_PROJECT` secrets from Credhub, instead of the S3 secrets files.

## How to review
1. See [the matching change in `paas-release-ci`](https://github.com/alphagov/paas-release-ci/pull/136)

## Who can review
Anyone
