### PR TITLE
Force prometheus to read recent from remote

### DIFF
--- a/provider/credentials.go
+++ b/provider/credentials.go
@@ -23,9 +23,14 @@ type InfluxDBPrometheusRemoteCredentials struct {
 	BasicAuthCredentials InfluxDBPrometheusBasicAuthCredentials `json:"basic_auth"`
 }
 
+type InfluxDBPrometheusRemoteReadCredentials struct {
+	InfluxDBPrometheusRemoteCredentials
+	ReadRecent bool `json:"read_recent"`
+}
+
 type InfluxDBPrometheusCredentials struct {
-	RemoteRead  []InfluxDBPrometheusRemoteCredentials `json:"remote_read"`
-	RemoteWrite []InfluxDBPrometheusRemoteCredentials `json:"remote_write"`
+	RemoteRead  []InfluxDBPrometheusRemoteReadCredentials `json:"remote_read"`
+	RemoteWrite []InfluxDBPrometheusRemoteCredentials     `json:"remote_write"`
 }
 
 type InfluxDBCredentials struct {
@@ -79,21 +84,23 @@ func addInfluxDBCredentials(credentials *Credentials) {
 		credentials.Hostname, credentials.Port,
 	)
 
-	credentials.InfluxDBPrometheus = &InfluxDBPrometheusCredentials{
-		RemoteRead: []InfluxDBPrometheusRemoteCredentials{{
-			URL: remoteReadURL,
-			BasicAuthCredentials: InfluxDBPrometheusBasicAuthCredentials{
-				Username: credentials.Username,
-				Password: credentials.Password,
-			},
-		}},
+	remoteReadCreds := InfluxDBPrometheusRemoteReadCredentials{}
+	remoteReadCreds.URL = remoteReadURL
+	remoteReadCreds.ReadRecent = true
+	remoteReadCreds.BasicAuthCredentials = InfluxDBPrometheusBasicAuthCredentials{
+		Username: credentials.Username,
+		Password: credentials.Password,
+	}
 
-		RemoteWrite: []InfluxDBPrometheusRemoteCredentials{{
-			URL: remoteWriteURL,
-			BasicAuthCredentials: InfluxDBPrometheusBasicAuthCredentials{
-				Username: credentials.Username,
-				Password: credentials.Password,
-			},
-		}},
+	remoteWriteCreds := InfluxDBPrometheusRemoteCredentials{}
+	remoteWriteCreds.URL = remoteWriteURL
+	remoteWriteCreds.BasicAuthCredentials = InfluxDBPrometheusBasicAuthCredentials{
+		Username: credentials.Username,
+		Password: credentials.Password,
+	}
+
+	credentials.InfluxDBPrometheus = &InfluxDBPrometheusCredentials{
+		RemoteRead:  []InfluxDBPrometheusRemoteReadCredentials{remoteReadCreds},
+		RemoteWrite: []InfluxDBPrometheusRemoteCredentials{remoteWriteCreds},
 	}
 }

--- a/provider/credentials_test.go
+++ b/provider/credentials_test.go
@@ -73,6 +73,7 @@ var _ = Describe("Credentials", func() {
 					"prometheus": {
 						"remote_read": [{
 							"url": "https://influxdb.aiven.io:2701/api/v1/prom/read?db=defaultdb",
+							"read_recent": true,
 							"basic_auth": {
 								"username": "hich",
 								"password": "rickey"


### PR DESCRIPTION
## What

When generating prometheus remote read configuration we should set read_recent to be true, so that prometheus goes to influx to get metrics

Otherwise prometheus may not read the metrics from the remote, depending on how recently prometheus has been started

## How to review

CI

To demonstrate this for a paas prometheus instance:
- `cf restart prometheus-service`
- Browse the graph page with `up` and verify that only recent results are displayed
- `cf ssh` onto the instance and add `"read_recent": true` to the `remote_read` section
- (SIGHUP) `kill -1 $prometheus pid`
- Browse the graph page with `up` and verify that all results are displayed

## Who can review

@paroxp 