### PR TITLE
include influxdb database name in binding credentials

### DIFF
--- a/ci/integration/integration_test.go
+++ b/ci/integration/integration_test.go
@@ -322,6 +322,7 @@ var _ = Describe("Broker", func() {
 			Expect(parsedResponse.Credentials).To(HaveKeyWithValue("port", BeAssignableToTypeOf(str)))
 			Expect(parsedResponse.Credentials).To(HaveKeyWithValue("username", BeAssignableToTypeOf(str)))
 			Expect(parsedResponse.Credentials).To(HaveKeyWithValue("password", BeAssignableToTypeOf(str)))
+			Expect(parsedResponse.Credentials).To(HaveKeyWithValue("database", BeAssignableToTypeOf(str)))
 
 			// Ensure returned credentials conform to Prometheus config format
 			// https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_read

--- a/provider/credentials.go
+++ b/provider/credentials.go
@@ -35,6 +35,7 @@ type InfluxDBPrometheusCredentials struct {
 
 type InfluxDBCredentials struct {
 	InfluxDBPrometheus *InfluxDBPrometheusCredentials `json:"prometheus,omitempty"`
+	InfluxDBDatabase   string                         `json:"database,omitempty"`
 }
 
 type Credentials struct {
@@ -103,4 +104,5 @@ func addInfluxDBCredentials(credentials *Credentials) {
 		RemoteRead:  []InfluxDBPrometheusRemoteReadCredentials{remoteReadCreds},
 		RemoteWrite: []InfluxDBPrometheusRemoteCredentials{remoteWriteCreds},
 	}
+	credentials.InfluxDBDatabase = "defaultdb"
 }

--- a/provider/credentials_test.go
+++ b/provider/credentials_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Credentials", func() {
 					"port": "2701",
 					"username": "hich",
 					"password": "rickey",
-
+					"database": "defaultdb",
 					"prometheus": {
 						"remote_read": [{
 							"url": "https://influxdb.aiven.io:2701/api/v1/prom/read?db=defaultdb",


### PR DESCRIPTION
## What

includes the name of the provided database in the binding credentials 

## Why

so that we have all the information required in VCAP_SERVICES to start reading/writing to the database.

## Context

the influxdb username/password/host/port provided in the credentials are not enough to connect and start using the database ... you also need to either create a database or use an existing one.

the provided credentials do not have permission to create databases, so we need to know the name of the database that is provided for us.

the database name "defaultdb" appears currently hardcoded in the prometheus-specific configuration credentials, but it isn't fun to parse it from there or to hardcoded it anywhere incase it changes.
