### PR TITLE
[#179252161] bump golang to 1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alphagov/paas-aiven-broker
 
-go 1.15
+go 1.16
 
 require (
 	code.cloudfoundry.org/lager v1.1.0

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,5 +5,5 @@ applications:
   instances: 2
   buildpack: go_buildpack
   env:
-    GOVERSION: go1.15
+    GOVERSION: go1.16
     GOPACKAGENAME: github.com/alphagov/paas-aiven-broker


### PR DESCRIPTION
## What

Bump the required version of golang in the module and cf manifest to 1.16, because we're about to roll out a buildpack which removes 1.15.

## How to review

Set a dev pipeline's `paas-aiven-broker` resource's `branch` to this one?

## Who can review

Human engineers.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨

