### PR TITLE
Unbinding idempotency fix

### DIFF
--- a/ci/integration/integration_test.go
+++ b/ci/integration/integration_test.go
@@ -224,6 +224,15 @@ var _ = Describe("Broker", func() {
 			})
 			Expect(res.Code).To(Equal(http.StatusOK))
 
+			By("Returning a 410 response when trying to unbind a non-existent binding")
+			res = brokerTester.Unbind(instanceID, bindingID, brokertesting.RequestBody{
+				ServiceID:        openSearchServiceGUID,
+				PlanID:           openSearchUpgradePlanGUID,
+				OrganizationGUID: orgGUID,
+				SpaceGUID:        spaceGUID,
+			})
+			Expect(res.Code).To(Equal(http.StatusGone))
+
 			By("Deprovisioning")
 			res = brokerTester.Deprovision(instanceID, openSearchServiceGUID, openSearchUpgradePlanGUID, asyncAllowed)
 			Expect(res.Code).To(Equal(http.StatusAccepted))
@@ -404,6 +413,17 @@ var _ = Describe("Broker", func() {
 				},
 			)
 			Expect(res.Code).To(Equal(http.StatusOK))
+
+			By("Returning a 410 response when trying to unbind a non-existent binding")
+			res = brokerTester.Unbind(
+				instanceID,
+				bindingID,
+				brokertesting.RequestBody{
+					ServiceID: influxDBServiceGUID,
+					PlanID:    influxDBPlanGUID,
+				},
+			)
+			Expect(res.Code).To(Equal(http.StatusGone))
 
 			By("Deprovisioning")
 			res = brokerTester.Deprovision(

--- a/provider/aiven/client_test.go
+++ b/provider/aiven/client_test.go
@@ -363,20 +363,20 @@ var _ = Describe("Client", func() {
 			Expect(actualResponse).To(Equal(""))
 		})
 
-		It("succeeds if an error saying the user does not exist is returned", func() {
+		It("returns ErrInstanceUserDoesNotExist if an error saying the user does not exist is returned", func() {
 			deleteServiceUserInput := &aiven.DeleteServiceUserInput{
 				ServiceName: "my-service",
 				Username:    "my-deleted-user",
 			}
-			response := `{"message": "Service user 'my-deleted-user' does not exist"}`
+			response := `{"errors":[{"message":"Service user does not exist","status":404}],"message":"Service user does not exist"}`
 			aivenAPI.AppendHandlers(ghttp.CombineHandlers(
 				ghttp.RespondWith(http.StatusForbidden, response),
 			))
 
 			actualResponse, err := aivenClient.DeleteServiceUser(deleteServiceUserInput)
 
-			Expect(err).ToNot(HaveOccurred())
-			Expect(actualResponse).To(Equal(response))
+			Expect(err).To(Equal(aiven.ErrInstanceUserDoesNotExist))
+			Expect(actualResponse).To(Equal(""))
 		})
 	})
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -270,6 +270,9 @@ func (ap *AivenProvider) Unbind(ctx context.Context, unbindData UnbindData) (err
 		ServiceName: ap.BuildServiceName(unbindData.InstanceID),
 		Username:    unbindData.BindingID,
 	})
+	if err == aiven.ErrInstanceUserDoesNotExist {
+		return apiresponses.ErrBindingDoesNotExist
+	}
 	return err
 }
 

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -544,7 +544,18 @@ var _ = Describe("Provider", func() {
 			Expect(fakeAivenClient.DeleteServiceUserArgsForCall(0)).To(Equal(expectedDeleteServiceUserParameters))
 		})
 
-		It("errors if the client errors", func() {
+		It("returns ErrBindingDoesNotExist if client returns ErrInstanceUserDoesNotExist", func() {
+			unbindData := provider.UnbindData{
+				InstanceID: "09E1993E-62E2-4040-ADF2-4D3EC741EFE6",
+				BindingID:  "D26EA3FB-AA78-451C-9ED0-233935ED388F",
+			}
+			fakeAivenClient.DeleteServiceUserReturnsOnCall(0, "", aiven.ErrInstanceUserDoesNotExist)
+
+			err := aivenProvider.Unbind(context.Background(), unbindData)
+			Expect(err).To(Equal(apiresponses.ErrBindingDoesNotExist))
+		})
+
+		It("errors if the client returns an unexpected error", func() {
 			unbindData := provider.UnbindData{
 				InstanceID: "09E1993E-62E2-4040-ADF2-4D3EC741EFE6",
 				BindingID:  "D26EA3FB-AA78-451C-9ED0-233935ED388F",


### PR DESCRIPTION
## What

https://www.pivotaltracker.com/story/show/184574195

Aiven appear to have updated their error message so our unbinding idempotency was broken. update string to reflect new one because we're not *quite* confident enough to interpret any 404 as the user simply being gone.

The osb spec actually suggests the correct response in this case should be 410 Gone aka `apiresponses.ErrBindingDoesNotExist`, so do that.

Also ensure we test unbinding idempotency in the integration tests now (we already test service deletion idempotency this way).

## How to review

:eyes: , see the integration tests passing, deploy it to a dev env or :eyes: at dev05 successfully deploying it: https://deployer.dev05.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/deploy-paas-aiven-broker/builds/13

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨

