### PR TITLE
Upgrade go to 1.22

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
 env:
-  GO_VERSION: "1.21"
+  GO_VERSION: "1.23"
 jobs:
   build:
     name: Build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
 env:
-  GO_VERSION: "1.23"
+  GO_VERSION: "1.22"
 jobs:
   build:
     name: Build

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alphagov/paas-aiven-broker
 
-go 1.23
+go 1.22
 
 require (
 	code.cloudfoundry.org/lager v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alphagov/paas-aiven-broker
 
-go 1.21
+go 1.23
 
 require (
 	code.cloudfoundry.org/lager v1.1.0

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,5 +5,5 @@ applications:
     instances: 2
     buildpack: go_buildpack
     env:
-      GOVERSION: go1.21
+      GOVERSION: go1.23
       GOPACKAGENAME: github.com/alphagov/paas-aiven-broker

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,5 +5,5 @@ applications:
     instances: 2
     buildpack: go_buildpack
     env:
-      GOVERSION: go1.23
+      GOVERSION: go1.22
       GOPACKAGENAME: github.com/alphagov/paas-aiven-broker


### PR DESCRIPTION
## What

Use go v1.22

> Initially intended to upgrade go to 1.23, but reverted to 1.22 due to current buildpack compatibility. Buildpack doesn't yet support 1.23.

## Why

To be up to date with the go buildpacks

## How to review

Ensure that the aiven broker deploys okay to a dev environment and passes tests

## Who can review

Current PaaS team members

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨

